### PR TITLE
Fix unresolved streaming settings reference

### DIFF
--- a/app/src/main/java/com/securecam/dashboard/ui/screens/AdminScreen.kt
+++ b/app/src/main/java/com/securecam/dashboard/ui/screens/AdminScreen.kt
@@ -136,7 +136,8 @@ fun AdminScreen(
                     camera = camera,
                     onEdit = { editing = camera },
                     onDelete = { onDelete(camera.id) },
-                    onSettings = { showStreamingSettings = camera }
+                    onSettings = { showStreamingSettings = camera },
+                    onResetAllStreamingSettings = onResetAllStreamingSettings
                 )
             }
         }
@@ -194,7 +195,8 @@ private fun CameraRow(
     camera: Camera,
     onEdit: () -> Unit,
     onDelete: () -> Unit,
-    onSettings: () -> Unit
+    onSettings: () -> Unit,
+    onResetAllStreamingSettings: () -> Unit
 ) {
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(


### PR DESCRIPTION
Add `onResetAllStreamingSettings` parameter to `CameraRow` to resolve an 'Unresolved reference' build error.

---
<a href="https://cursor.com/background-agent?bcId=bc-0e39763c-cb5f-4111-81f6-644828ae1319">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0e39763c-cb5f-4111-81f6-644828ae1319">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

