### PR TITLE
Fix camera crash and remove udp setting

### DIFF
--- a/app/src/main/java/com/securecam/dashboard/data/Models.kt
+++ b/app/src/main/java/com/securecam/dashboard/data/Models.kt
@@ -54,8 +54,7 @@ data class StreamingSettings(
     fun validate(): StreamingSettings {
         return copy(
             networkCachingMs = networkCachingMs.coerceIn(50, 15000),
-            useTcp = if (!useTcp && !useUdp) true else useTcp, // Ensure at least one protocol is selected
-            useUdp = if (!useTcp && !useUdp) false else useUdp,
+            // No forced protocol selection; rely on VLC defaults,
             bufferSize = bufferSize.coerceIn(128, 16384),
             maxLatency = maxLatency.coerceIn(0, 10000),
             clockJitter = clockJitter.coerceIn(0, 2000),
@@ -81,8 +80,7 @@ data class StreamingSettings(
      * Checks if the streaming settings are valid
      */
     fun isValid(): Boolean {
-        return (useTcp || useUdp) && // At least one protocol must be selected
-               networkCachingMs in 50..15000 &&
+        return networkCachingMs in 50..15000 &&
                bufferSize in 128..16384 &&
                maxLatency in 0..10000 &&
                clockJitter in 0..2000 &&

--- a/app/src/main/java/com/securecam/dashboard/ui/components/StreamingSettingsDialog.kt
+++ b/app/src/main/java/com/securecam/dashboard/ui/components/StreamingSettingsDialog.kt
@@ -47,60 +47,7 @@ fun StreamingSettingsDialog(
                     modifier = Modifier.fillMaxWidth()
                 )
                 
-                // Protocol Selection
-                Text("Protocol Settings", style = MaterialTheme.typography.titleSmall)
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(16.dp)
-                ) {
-                    Row(verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
-                        Checkbox(
-                            checked = localSettings.useTcp,
-                            onCheckedChange = { 
-                                if (it) {
-                                    localSettings = localSettings.copy(
-                                        useTcp = true,
-                                        useUdp = false
-                                    )
-                                } else if (!localSettings.useUdp) {
-                                    // Ensure at least one protocol is selected
-                                    localSettings = localSettings.copy(useTcp = true)
-                                } else {
-                                    localSettings = localSettings.copy(useTcp = false)
-                                }
-                            }
-                        )
-                        Text("TCP (More stable)")
-                    }
-                    Row(verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
-                        Checkbox(
-                            checked = localSettings.useUdp,
-                            onCheckedChange = { 
-                                if (it) {
-                                    localSettings = localSettings.copy(
-                                        useUdp = true,
-                                        useTcp = false
-                                    )
-                                } else if (!localSettings.useTcp) {
-                                    // Ensure at least one protocol is selected
-                                    localSettings = localSettings.copy(useUdp = true)
-                                } else {
-                                    localSettings = localSettings.copy(useUdp = false)
-                                }
-                            }
-                        )
-                        Text("UDP (Lower latency)")
-                    }
-                }
-                
-                // Protocol validation warning
-                if (!localSettings.useTcp && !localSettings.useUdp) {
-                    Text(
-                        text = "⚠️ At least one protocol must be selected",
-                        color = MaterialTheme.colorScheme.error,
-                        style = MaterialTheme.typography.bodySmall
-                    )
-                }
+                // Protocol selection removed; rely on LibVLC defaults
                 
                 // Buffer Settings
                 OutlinedTextField(

--- a/app/src/main/java/com/securecam/dashboard/ui/components/VlcPlayer.kt
+++ b/app/src/main/java/com/securecam/dashboard/ui/components/VlcPlayer.kt
@@ -45,18 +45,8 @@ fun VlcPlayer(
             options.add("--avcodec-threads=${streamingSettings.avcodecThreads}") // Thread count
         }
         
-        // Protocol selection - CRITICAL FIX: Only one protocol at a time
-        when {
-            streamingSettings.useUdp -> {
-                options.add("--rtsp-udp")
-                options.add("--rtsp-tcp=0") // Explicitly disable TCP
-            }
-            else -> {
-                options.add("--rtsp-tcp")
-                options.add("--rtsp-udp=0") // Explicitly disable UDP
-            }
-        }
-        
+        // Transport protocol: rely on LibVLC defaults (no forced TCP/UDP flags)
+
         // Advanced network optimizations
         options.add("--adaptive-maxbuffer=${streamingSettings.adaptiveMaxBuffer}")
         options.add("--adaptive-minbuffer=${streamingSettings.adaptiveMinBuffer}")
@@ -95,17 +85,7 @@ fun VlcPlayer(
         }
         
         // RTSP specific optimizations
-        if (streamingSettings.useUdp) {
-            // UDP specific optimizations
-            options.add("--network-caching=${(streamingSettings.networkCachingMs * 0.5).toInt().coerceAtLeast(50)}")
-            options.add("--live-caching=${(streamingSettings.networkCachingMs * 0.5).toInt().coerceAtLeast(50)}")
-            options.add("--multicast-ttl=${streamingSettings.multicastTtl}")
-            options.add("--jitter-buffer-size=${streamingSettings.jitterBufferSize}")
-        } else {
-            // TCP specific optimizations
-            options.add("--network-caching=${streamingSettings.networkCachingMs}")
-            options.add("--live-caching=${streamingSettings.networkCachingMs}")
-        }
+        // No explicit RTSP protocol options as transport is handled by LibVLC
         
         // Adaptive buffering
         if (streamingSettings.enableAdaptiveBuffering) {
@@ -115,13 +95,7 @@ fun VlcPlayer(
         }
         
         // Jitter buffer for UDP streams
-        if (streamingSettings.useUdp) {
-            options.add("--clock-jitter=${streamingSettings.clockJitter}")
-            options.add("--clock-synchro=0") // Disable clock sync for UDP
-        } else {
-            options.add("--clock-jitter=${streamingSettings.clockJitter}")
-            options.add("--clock-synchro=${streamingSettings.clockSynchro}")
-        }
+        // No explicit Jitter buffer options as transport is handled by LibVLC
         
         // Low latency mode optimizations
         if (streamingSettings.lowLatencyMode) {

--- a/app/src/main/java/com/securecam/dashboard/ui/screens/AdminScreen.kt
+++ b/app/src/main/java/com/securecam/dashboard/ui/screens/AdminScreen.kt
@@ -267,11 +267,6 @@ private fun StreamingSettingsSummary(settings: StreamingSettings) {
         )
         Text(
             "Cache: ${settings.networkCachingMs}ms, " +
-                    "Protocol: ${when {
-                        settings.useTcp -> "TCP"
-                        settings.useUdp -> "UDP"
-                        else -> "Auto"
-                    }}, " +
                     "Buffer: ${settings.bufferSize}KB",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant


### PR DESCRIPTION
Remove explicit TCP/UDP streaming protocol selection to prevent app crashes and leverage LibVLC's default protocol handling.

---
<a href="https://cursor.com/background-agent?bcId=bc-9edd8d32-814c-43db-8858-2bdca2ff29b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9edd8d32-814c-43db-8858-2bdca2ff29b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

